### PR TITLE
Fixed 500 when expansion is selected and base game is not selected

### DIFF
--- a/app.js
+++ b/app.js
@@ -43,8 +43,10 @@ function runServer(games) {
       var gameKey = parseInt(key.substring(1, key.length));
       var expansionKeys = this.request.body.expansions[key];
       Object.keys((expansionKeys || {})).forEach((expansionIndex) => {
-        requestedGames.filter((g) => g.id == gameKey)[0].expansions.push(
-          games[gameKey].expansions[expansionKeys[expansionIndex]]);
+        requestedGame = requestedGames.filter((g) => g.id == gameKey)[0]
+        if (requestedGame != null) {
+          requestedGame.expansions.push(games[gameKey].expansions[expansionKeys[expansionIndex]]);
+        }
       });
     })
     this.render('generate', {requestedGames: requestedGames});


### PR DESCRIPTION
This change just ignores selected expansions when the base game is not selected.  I think it'd be cool to either display the expansion by itself, or to automatically select the base game checkbox when an expansion is selected (and vice-versa), but this corrects the Internal Server Error for now.